### PR TITLE
fix: update Dependabot labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore(deps)"
+    labels: ["python", "dependencies"]
     groups:
       dependencies:
         applies-to: version-updates
@@ -19,6 +20,7 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore(deps)"
+    labels: ["github_actions", "dependencies"]
     groups:
       dependencies:
         applies-to: version-updates
@@ -31,6 +33,7 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "chore(deps)"
+    labels: ["docker", "dependencies"]
     groups:
       dependencies:
         applies-to: version-updates

--- a/.github/linters/trivy.yaml
+++ b/.github/linters/trivy.yaml
@@ -1,0 +1,3 @@
+scan:
+  skip-dirs:
+    - .mypy_cache

--- a/.github/linters/zizmor.yaml
+++ b/.github/linters/zizmor.yaml
@@ -1,0 +1,6 @@
+rules:
+  dangerous-triggers: # to allow pull_request_target for auto-labelling fork pull requests
+    ignore:
+      - auto-labeler.yml
+      - pr-title.yml
+      - release.yml

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -15,5 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5.0.0
+        with:
+          persist-credentials: false
       - name: Build the Docker image
         run: docker build . --file Dockerfile --platform linux/amd64 --tag measure-innersource:"$(date +%s)"

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -23,14 +23,15 @@ jobs:
           # Full git history is needed to get a proper
           # list of changed files within `super-linter`
           fetch-depth: 0
-      - uses: actions/setup-python@v5.6.0
+          persist-credentials: false
+      - uses: actions/setup-python@v6.0.0
         with:
           python-version: "3.12"
       - name: Install dependencies
         run: |
           pip install -r requirements.txt -r requirements-test.txt
       - name: Lint Code Base
-        uses: super-linter/super-linter@5119dcd8011e92182ce8219d9e9efc82f16fddb6 # v8.0.0
+        uses: super-linter/super-linter@ffde3b2b33b745cb612d787f669ef9442b1339a6 # v8.1.0
         env:
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -22,8 +22,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5.0.0
+        with:
+          persist-credentials: false
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5.6.0
+        uses: actions/setup-python@v6.0.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,8 +17,18 @@ COPY requirements.txt *.py /action/workspace/
 
 RUN python3 -m pip install --no-cache-dir -r requirements.txt \
     && apt-get -y update \
-    && apt-get -y install --no-install-recommends git=1:2.47.2-0.2 \
-    && rm -rf /var/lib/apt/lists/*
+    && apt-get -y install --no-install-recommends git=1:2.47.3-0+deb13u1 \
+    && rm -rf /var/lib/apt/lists/* \
+    && addgroup --system appuser \
+    && adduser --system --ingroup appuser --home /action/workspace --disabled-login appuser \
+    && chown -R appuser:appuser /action/workspace
+
+# Run the action as a non-root user
+USER appuser
+
+# Add a simple healthcheck to satisfy container scanners
+HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
+  CMD python3 -c "import os,sys; sys.exit(0 if os.path.exists('/action/workspace/measure_innersource.py') else 1)"
 
 CMD ["/action/workspace/measure_innersource.py"]
 ENTRYPOINT ["python3", "-u"]


### PR DESCRIPTION
# Pull Request

<!--
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes

Based on [Dependabot docs](https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#labels--) we can specify the labels applied. Previously Dependabot was applying `major`, `minor', or `patch` labels based on the version of dependency updates. This was causing conflicts with our auto releasing. If those labels were present they were being applied to our releases. This is not what we want. We are chaning to just note the package type (i.e., go, github_actions, etc) and `dependencies`, in case we ever need to filter in the UI.

## Readiness Checklist

### Author/Contributor

- [ ] If documentation is needed for this change, has that been included in this pull request
- [ ] run `make lint` and fix any issues that you have introduced
- [ ] run `make test` and ensure you have test coverage for the lines you are introducing
- [ ] If publishing new data to the public (scorecards, security scan results, code quality results, live dashboards, etc.), please request review from `@jeffrey-luszcz`

### Reviewer

- [ ] Label as either `fix`, `documentation`, `enhancement`, `infrastructure`, `maintenance`, or `breaking`
