### PR TITLE
fix: convert gh_app_id to string before login_as_app_installation call

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ __pycache__/
 # C extensions
 *.so
 
+# ai
+**/.claude/*.local.*
+
 # JSCPD
 report/
 

--- a/auth.py
+++ b/auth.py
@@ -86,7 +86,7 @@ def auth_to_github(
         else:
             gh = github3.github.GitHub()
         gh.login_as_app_installation(
-            gh_app_private_key_bytes, gh_app_id, gh_app_installation_id
+            gh_app_private_key_bytes, str(gh_app_id), gh_app_installation_id
         )
         github_connection = gh
     elif ghe and token:

--- a/test_auth.py
+++ b/test_auth.py
@@ -67,7 +67,35 @@ class TestAuthToGithub(unittest.TestCase):
         result = auth_to_github(
             "", "123", "123", b"123", "https://github.example.com", True
         )
-        mock.login_as_app_installation.assert_called_once()
+        mock.login_as_app_installation.assert_called_once_with(b"123", "123", "123")
+        self.assertEqual(result, mock)
+
+    @patch("github3.github.GitHub")
+    def test_auth_to_github_with_app(self, mock_gh):
+        """
+        Test the auth_to_github function when the GitHub App
+        parameters are provided without enterprise-only flag.
+        """
+        mock = mock_gh.return_value
+        mock.login_as_app_installation = MagicMock(return_value=True)
+        result = auth_to_github(
+            "", "123", "123", b"123", "https://github.example.com", False
+        )
+        mock.login_as_app_installation.assert_called_once_with(b"123", "123", "123")
+        self.assertEqual(result, mock)
+
+    @patch("github3.github.GitHub")
+    def test_auth_to_github_with_app_int_app_id(self, mock_gh):
+        """
+        Test that an integer app_id is converted to a string before passing
+        to login_as_app_installation, to avoid PyJWT TypeError on the iss claim.
+        """
+        mock = mock_gh.return_value
+        mock.login_as_app_installation = MagicMock(return_value=True)
+        result = auth_to_github("", 123, 456, b"private_key", "", False)
+        mock.login_as_app_installation.assert_called_once_with(
+            b"private_key", "123", 456
+        )
         self.assertEqual(result, mock)
 
     @patch("github3.apps.create_jwt_headers", MagicMock(return_value="gh_token"))


### PR DESCRIPTION
# Pull Request

<!--
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes

<!-- Describe what the changes are and link to a GitHub Issue if one exists -->

### What

Wrapped gh_app_id with str() in the login_as_app_installation call in auth.py, added targeted tests for integer app_id inputs, and tightened existing test assertions to verify exact call arguments. Also added .claude local files to .gitignore.

### Why

When gh_app_id is passed as an integer, PyJWT raises a TypeError on the iss claim during JWT encoding because it expects a string. This surfaces at runtime when the environment variable is parsed as an int rather than str.

### Notes

- Only gh_app_id is converted; gh_app_installation_id is left as-is since login_as_app_installation accepts it in its original form
- The existing test previously used assert_called_once() without argument checks, so type mismatches like this were invisible; the tightened assertions now catch them
- Mirrors the fix in github-community-projects/cleanowners#340


## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing
