### PR TITLE
build: pin uv version and add linter concurrency

### DIFF
--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -5,6 +5,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 
@@ -27,6 +31,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
         with:
+          version: "0.10.9"
           enable-cache: true
       - name: Install dependencies
         run: |

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
         with:
+          version: "0.10.9"
           enable-cache: true
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}

--- a/.github/workflows/update-uv-lock.yml
+++ b/.github/workflows/update-uv-lock.yml
@@ -29,6 +29,9 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
+        with:
+          version: "0.10.9"
+          enable-cache: true
 
       - name: Update uv.lock
         run: uv lock


### PR DESCRIPTION
## What

Pin astral-sh/setup-uv to version 0.10.9 with caching enabled across all CI workflows, and add a concurrency group to the linter workflow to cancel in-progress runs on the same branch.

## Why

Pinning the uv version prevents unexpected breakage from new uv releases while enable-cache speeds up CI runs. The concurrency group avoids wasting CI minutes on outdated linter runs when new commits are pushed.

## Notes

- The version pin means dependabot won't auto-update uv — manual bumps will be needed when upgrading.
- Caching is now enabled on update-uv-lock.yml too; verify this doesn't interfere with lock file regeneration.